### PR TITLE
Update parameters in other options

### DIFF
--- a/src/karabiner_configurator/rules.clj
+++ b/src/karabiner_configurator/rules.clj
@@ -194,7 +194,7 @@
 ;; parameters                                     | :params
 ;;   basic.to_if_alone_timeout_milliseconds       |   :alone
 ;;   basic.to_if_held_down_threshold_milliseconds |   :held
-;;   to_delayed_action_delay_milliseconds         |   :delay  FIXME should there be a "basic.", there's none on the spec page
+;;   basic.to_delayed_action_delay_milliseconds   |   :delay
 ;;   basic.simultaneous_threshold_milliseconds    |   :sim
 (defn additional-key
   "parse additional keys"


### PR DESCRIPTION
Change `to_delayed_action_delay_milliseconds` to `basic.to_delayed_action_delay_milliseconds`.
Remove `FIXME should there be a "basic.", there's none on the spec page`.
It's there in the doc - https://karabiner-elements.pqrs.org/docs/json/complex-modifications-manipulator-definition/to-delayed-action/#parameters.