### PR TITLE
Add caps_lock as a modifier in the tutorial

### DIFF
--- a/tutorial.md
+++ b/tutorial.md
@@ -132,6 +132,7 @@ The only condition that Goku does not support is [keyboard type](https://pqrs.or
     ;; W  | right_control
     ;; E  | right_option
     ;; R  | right_shift
+    ;; P  | caps_lock
     ;; !! | mandatory command + control + optional + shift (hyper)
     ;; ## | optional any
     


### PR DESCRIPTION
When caps lock is pressed, it affects things. This is an accepted modifier and can be used as such in from constructs such as ```:!C#Pq``` which translates to "when Cmd+q is pressed, regardless of CapsLock being active or not".