### PR TITLE
Add support of "dictation" key

### DIFF
--- a/src/karabiner_configurator/keys_info.clj
+++ b/src/karabiner_configurator/keys_info.clj
@@ -146,7 +146,7 @@
    :rewind {:not-from true :consumer-key true}
    :play_or_pause {:not-from true :consumer-key true}
    :fastforward {:not-from true :consumer-key true}
-   :dictation {:consumer-key true}
+   :dictation {:not-from true :consumer-key true}
    :mute {:consumer-key true}
    :volume_decrement {:consumer-key true}
    :volume_increment {:consumer-key true}

--- a/src/karabiner_configurator/keys_info.clj
+++ b/src/karabiner_configurator/keys_info.clj
@@ -146,6 +146,7 @@
    :rewind {:not-from true :consumer-key true}
    :play_or_pause {:not-from true :consumer-key true}
    :fastforward {:not-from true :consumer-key true}
+   :dictation {:consumer-key true}
    :mute {:consumer-key true}
    :volume_decrement {:consumer-key true}
    :volume_increment {:consumer-key true}


### PR DESCRIPTION
`dictation` key is Fn+F5 key on Mak Book Air.
This key code works with Karabiner Elements 14.4. I've tested by manually adding to the `karabiner.json`

![CleanShot 2022-04-22 at 17 52 36@2x](https://user-images.githubusercontent.com/11693557/164739667-091b9dbc-b5b6-48fe-866a-c3c581a5152d.png)
