### PR TITLE
don't force joker path to be hardcoded

### DIFF
--- a/src/karabiner_configurator/core.clj
+++ b/src/karabiner_configurator/core.clj
@@ -33,11 +33,11 @@
         joker-bin2 "/opt/homebrew/opt/joker/bin/joker"
         ;; nix
         joker-bin3 (str (System/getenv "HOME") "/.nix-profile/bin/joker")
-        ;; fallback to brew --prefix joker, it's really slow
+        ;; fallback to which joker
         joker-bin (cond (fs/exists? joker-bin1) joker-bin1
                         (fs/exists? joker-bin2) joker-bin2
                         (fs/exists? joker-bin3) joker-bin3
-                        :else (-> (shell/sh "brew" "--prefix" "joker")
+                        :else (-> (shell/sh "which" "joker")
                                   :out
                                   (string/trim-newline)
                                   (str "/bin/joker")))]


### PR DESCRIPTION
Look up joker location using `which joker` instead of assuming homebrew installation. Current version hardcodes joker path and doesn't cover all cases (e.g. for a home-manager based nix config, joker is located at `/etc/profiles/per-user/$USER/bin/joker`), causing execution to fail.