### PR TITLE
Add example for two-stroke keybinding

### DIFF
--- a/examples.org
+++ b/examples.org
@@ -393,3 +393,22 @@ Don't map a to b when there are three fingers on the trackpad.
                      ;; 2. cleanup notification :id :cmdq
                      :canceled [["command-q" 0] [:noti :cmdq]]}}]]}
 #+end_src
+
+** Two-Stroke Keybindings (Emacs C-x Mode)
+
+This setup can be used for keybindings where you press one key, then quickly another key to execute a to action. The order is important: all the conditional bindings must come _before_ the line with the delayed declaration
+
+#+NAME: two-stroke keybindings 
+#+BEGIN_SRC clojure
+{:des "tap right shift then keys"
+ :rules [
+         ; If right-shift-mode is on, run this command when a is pressed. Anything that depends
+         ; on the mode being set must come _before_ the delayed declaration.
+         [:a "open https://github.com/yqrashawn/GokuRakuJoudo" [:right-shift-mode]]
+         ; Send right_shift unconditionally (so it still works as a modifier key)
+         [:right_shift :right_shift nil
+          ; and if pressed alone, trigger right-shift-mode
+          {:alone [:right_shift ["right-shift-mode" 1]]
+           ; when another key is invoked, or after a timeout, set the mode back to zero
+           :delayed {:invoked ["right-shift-mode" 0] :canceled ["right-shift-mode" 0]}}]]}
+#+END_SRC


### PR DESCRIPTION
Hi! I really love Goku and after reading about [`to_delayed_action`](https://karabiner-elements.pqrs.org/docs/json/complex-modifications-manipulator-definition/to-delayed-action/) on the Karabiner docs I was excited to try it out.

After a bunch of frustration trying to get it to work, I discovered that the actions that depend on the conditional being set need to be declared first. This makes sense (I guess Karabiner evaluates the manipulations in order), but it was totally non-obvious at first and the Karabiner docs don't have a good example of this specific case, or one that also sends the first key so it is still usable (ie has an `:alone`). I thought I would add one here because I think it could be really useful. If you don't think so, feel free to close!