### PR TITLE
feat: allow using ⇧symbols instead of R

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ pom.xml.asc
 /.clj-kondo/.cache/
 /.cpcache/
 /karabiner-configurator-0.1.0-standalone.build_artifacts.txt
+ReadMe.html
+KeySymbols.html

--- a/KeySymbols.md
+++ b/KeySymbols.md
@@ -38,6 +38,7 @@ __NB!__
   - Optional﹖ indicator __must__ bet at the Right side and __after__ the side indicator (✓`⎈›﹖` ✗`⎈﹖›`)
   - Modifiers at the end of a key definition are treated as literal keys
   - Keys-as-strings __must__ have a `‘` in the beginning to differentiate them from, e.g., strings that contain script commands
+  - User functions need to escape special symbols listed here with `_` (`[:e [:echo␠ "e"]]`→`[:e [:echo_␠ "e"]]`) to avoid conflict
 
 ### Other key symbols
 

--- a/KeySymbols.md
+++ b/KeySymbols.md
@@ -47,7 +47,9 @@ __NB!__
   |🌐 ƒ ⓕ Ⓕ 🄵 🅕 🅵 	|`!F`                                      	|
   |⇪             	|`P`  capslock                             	|
   |∀             	|`!A` any modifier regardless of side      	|
-  |✱             	|`!!` hyper                                	|
+  |✱             	|`!!` left-side "hyper" (‹⇧‹⎈‹⎇‹◆)         	|
+  |✱›            	|right-side "hyper" (⇧›⎈›⎇›◆›)             	|
+  |✦             	|right-side "hyper" (⇧›⎈›⎇›◆›)             	|
   |∀﹖ ∀? ﹖﹖ ??   	|`##` optional any                         	|
   |⎋             	|`escape`                                  	|
   |⭾ ↹           	|`tab`                                     	|

--- a/KeySymbols.md
+++ b/KeySymbols.md
@@ -1,0 +1,56 @@
+## New modifiers symbols vs Current
+  |↓Label type    	| Key→	|Shift	|Ctrl	|Ctrl	|Alt 	|Alt 	|Cmd 	|Cmd 	|
+  |:--------------	| :-  	|  :-:	| :-:	| :-:	| :-:	| :-:	| :-:	| :-:	|
+  |Any (mandatory)	|     	| ⇧   	|  ⎈ 	| ⌃  	|  ⎇ 	| ⌥  	| ⌘  	| ◆  	|
+  |+ Left         	|‹ `'`	| ‹⇧  	|    	|    	|    	|    	|    	|    	|
+  |+ Right        	|› `'`	| ⇧›  	|    	|    	|    	|    	|    	|    	|
+  |+ Optional     	|﹖ ?  	|   ⇧﹖	|    	|    	|    	|    	|    	|    	|
+  |Current Left   	|     	| S   	|  T 	| T  	|  O 	| O  	|  C 	| C  	| 
+  |...Right       	|     	| R   	|  W 	| W  	|  E 	| E  	|  Q 	| Q  	| 
+  |...Any         	|     	| SS  	|  TT	| TT 	|  OO	| OO 	|  CC	| CC 	| 
+  |+ Mandatory    	|!    	| !S  	|    	|    	|    	|    	|    	|    	|
+  |+ Optional     	|#    	| #S  	|    	|    	|    	|    	|    	|    	|
+
+Examples
+
+  |New label      	| Side 	| Must/opt 	| Key    	|Old	|
+  |:--------------	| :-   	|  :-      	| :-     	| :-	|
+  |‹⇧             	| left 	| mandatory	| shift  	| !S	|
+  |⎈›             	| right	| mandatory	| control	| !W	|
+  |⎇›﹖            	| right	| optional 	| alt    	| #E	|
+
+__NB!__
+
+  - Left/Right side indicators __must__ be at their respective sides (‹Left, Right›)
+  - Optional﹖ indicator __must__ bet at the Right side and __after__ the side indicator (✓`⎈›﹖` ✗`⎈﹖›`)
+
+### Other key symbols
+
+  |Symbol(s)[^1] 	|Key `name`                          	|
+  |---------     	|--------                            	|
+  |🌐 ƒ ⓕ Ⓕ 🄵 🅕 🅵 	|`!F`                                	|
+  |⇪             	|`P`  capslock                       	|
+  |∀             	|`!A` any modifier regardless of side	|
+  |✱             	|`!!` hyper                          	|
+  |﹖﹖ ??         	|`##` optional any                   	|
+  |⎋             	|`escape`                            	|
+  |⭾ ↹           	|`tab`                               	|
+  |␠ ␣           	|`spacebar`                          	|
+  |␈ ⌫           	|`delete_or_backspace`               	|
+  |␡ ⌦           	|`delete_forward`                    	|
+  |⏎ ↩ ⌤ ␤       	|`return_or_enter`                   	|
+  |︔ ⸴ ．         	|`semicolon` / `comma` / `period`    	|
+  |ˋ ˜           	|`grave_accent_and_tilde`            	|
+  |₌             	|`equal_sign`                        	|
+  |▲ ▼ ◀ ▶       	|`up`/`down`/`left`/`right` `_arrow`
+  |⇞ ⇟           	|`page_` `up`/`down`                   	|
+  |⇤ ⤒ ↖         	|`home`                                	|
+  |⇥ ⤓ ↘         	|`end`                                 	|
+  | ` `          	|no-break space removed                	|
+  |🔢₁ 🔢₂ 🔢₃ 🔢₄ 🔢₅	|`keypad_` `1`–`5`                     	|
+  |🔢₆ 🔢₇ 🔢₈ 🔢₉ 🔢₀	|`keypad_` `6`–`0`                     	|
+  |🔢₋ 🔢₌ 🔢₊      	|`keypad_` `hyphen`/`equal_sign`/`plus`	|
+  |🔢⁄ 🔢．🔢∗       	|`keypad_` `slash`/`period`/`asterisk` 	|
+
+[^1]: space-separated list of keys
+

--- a/KeySymbols.md
+++ b/KeySymbols.md
@@ -20,11 +20,24 @@ Examples
   |⎇›﹖            	| right	| optional 	| alt    	| #E     	|
   |⎇›⇧            	| right	| optional 	| alt    	| !Eshift	|
 
+You can also input keys as strings to include whitespace which is helpful to achieve vertical alignment like so:
+```edn
+{:des "Vertically aligned modifiers in the FROM keys, note the mandatory ‘ at the beginning" :rules [
+  ["‘‹⎈       k" :k]
+  ["‘  ‹⇧     k" :k]
+  ["‘   ⇧›    k" :k]
+  ["‘   ⇧   ⎇k" :k]
+  ["‘     ‹⌘  k" :k]
+  ["‘       ⎇k" :k]
+]}
+```
+
 __NB!__
 
   - Left/Right side indicators __must__ be at their respective sides (‹Left, Right›)
   - Optional﹖ indicator __must__ bet at the Right side and __after__ the side indicator (✓`⎈›﹖` ✗`⎈﹖›`)
   - Modifiers at the end of a key definition are treated as literal keys
+  - Keys-as-strings __must__ have a `‘` in the beginning to differentiate them from, e.g., strings that contain script commands
 
 ### Other key symbols
 

--- a/KeySymbols.md
+++ b/KeySymbols.md
@@ -28,31 +28,49 @@ __NB!__
 
 ### Other key symbols
 
-  |Symbol(s)[^1] 	|Key `name`                          	|
-  |---------     	|--------                            	|
-  |🌐 ƒ ⓕ Ⓕ 🄵 🅕 🅵 	|`!F`                                	|
-  |⇪             	|`P`  capslock                       	|
-  |∀             	|`!A` any modifier regardless of side	|
-  |✱             	|`!!` hyper                          	|
-  |﹖﹖ ??         	|`##` optional any                   	|
-  |⎋             	|`escape`                            	|
-  |⭾ ↹           	|`tab`                               	|
-  |␠ ␣           	|`spacebar`                          	|
-  |␈ ⌫           	|`delete_or_backspace`               	|
-  |␡ ⌦           	|`delete_forward`                    	|
-  |⏎ ↩ ⌤ ␤       	|`return_or_enter`                   	|
-  |︔ ⸴ ．         	|`semicolon` / `comma` / `period`    	|
-  |ˋ ˜           	|`grave_accent_and_tilde`            	|
-  |₌             	|`equal_sign`                        	|
+  |Symbol(s)[^1] 	|Key `name`                                	|
+  |---------     	|--------                                  	|
+  |🌐 ƒ ⓕ Ⓕ 🄵 🅕 🅵 	|`!F`                                      	|
+  |⇪             	|`P`  capslock                             	|
+  |∀             	|`!A` any modifier regardless of side      	|
+  |✱             	|`!!` hyper                                	|
+  |∀﹖ ∀? ﹖﹖ ??   	|`##` optional any                         	|
+  |⎋             	|`escape`                                  	|
+  |⭾ ↹           	|`tab`                                     	|
+  |␠ ␣           	|`spacebar`                                	|
+  |␈ ⌫           	|`delete_or_backspace`                     	|
+  |␡ ⌦           	|`delete_forward`                          	|
+  |⏎ ↩ ⌤ ␤       	|`return_or_enter`                         	|
+  |︔ ⸴ ．⁄        	|`semicolon` / `comma` / `period` / `slash`	|
+  |“ ” ＂ « »     	|`quote`                                   	|
+  |⧵ ＼           	|`backslash`                               	|
+  |﹨             	|`non_us_backslash`                        	|
+  |【 「 〔 ⎡       	|`open_bracket`                            	|
+  |】 」 〕 ⎣       	|`close_bracket`                           	|
+  |£             	|`non_us_pound`                            	|
+  |ˋ ˜           	|`grave_accent_and_tilde`                  	|
+  |‐ ₌           	|`hyphen` `equal_sign`                     	|
   |▲ ▼ ◀ ▶       	|`up`/`down`/`left`/`right` `_arrow`
-  |⇞ ⇟           	|`page_` `up`/`down`                   	|
-  |⇤ ⤒ ↖         	|`home`                                	|
-  |⇥ ⤓ ↘         	|`end`                                 	|
-  | ` `          	|no-break space removed                	|
-  |🔢₁ 🔢₂ 🔢₃ 🔢₄ 🔢₅	|`keypad_` `1`–`5`                     	|
-  |🔢₆ 🔢₇ 🔢₈ 🔢₉ 🔢₀	|`keypad_` `6`–`0`                     	|
-  |🔢₋ 🔢₌ 🔢₊      	|`keypad_` `hyphen`/`equal_sign`/`plus`	|
-  |🔢⁄ 🔢．🔢∗       	|`keypad_` `slash`/`period`/`asterisk` 	|
+  |⇞ ⇟           	|`page_` `up`/`down`                    	|
+  |⇤ ⤒ ↖         	|`home`                                 	|
+  |⇥ ⤓ ↘         	|`end`                                  	|
+  | ` `          	|no-break space removed                 	|
+  |🔢₁ 🔢₂ 🔢₃ 🔢₄ 🔢₅	|`keypad_` `1`–`5`                      	|
+  |🔢₆ 🔢₇ 🔢₈ 🔢₉ 🔢₀	|`keypad_` `6`–`0`                      	|
+  |🔢₋ 🔢₌ 🔢₊      	|`keypad_` `hyphen`/`equal_sign`/`plus` 	|
+  |🔢⁄ 🔢．🔢∗       	|`keypad_` `slash`/`period`/`asterisk`  	|
+  |◀◀ ▶⏸ ▶▶      	|`vk_consumer_` `previous`/`play`/`next`	|
+  |🔊 🔈+ or ➕₊⊕   	|`volume_up`                            	|
+  |🔉 🔈− or ➖₋⊖   	|`volume_down`                          	|
+  |🔇 🔈⓪ ⓿ ₀      	|`mute`                                 	|
+  |🔆 🔅           	|`vk_consumer_brightness_` `up`/`down`  	|
+  |⌨💡+ or ➕₊⊕    	|`vk_consumer_illumination_up`          	|
+  |⌨💡− or ➖₋⊖    	|`vk_consumer_illumination_down`        	|
+  |▦             	|`vk_launchpad`                         	|
+  |🎛             	|`vk_dashboard`                         	|
+  |▭▯            	|`vk_mission_control`                   	|
+  |▤ ☰ 𝌆         	|`application`                          	|
+  |🖰1 🖰2 ... 🖰32 	|`button` `1`–`32`                      	|
 
-[^1]: space-separated list of keys
+[^1]: space-separated list of keys; `or` means only last symbol in a pair changes
 

--- a/KeySymbols.md
+++ b/KeySymbols.md
@@ -1,15 +1,15 @@
 ## New modifiers symbols vs Current
-  |↓Label type    	| Key→	|Shift	|Ctrl	|Ctrl	|Alt 	|Alt 	|Cmd 	|Cmd 	|
-  |:--------------	| :-  	|  :-:	| :-:	| :-:	| :-:	| :-:	| :-:	| :-:	|
-  |Any (mandatory)	|     	| ⇧   	|  ⎈ 	| ⌃  	|  ⎇ 	| ⌥  	| ⌘  	| ◆  	|
-  |+ Left         	|‹ `'`	| ‹⇧  	|    	|    	|    	|    	|    	|    	|
-  |+ Right        	|› `'`	| ⇧›  	|    	|    	|    	|    	|    	|    	|
-  |+ Optional     	|﹖ ?  	|   ⇧﹖	|    	|    	|    	|    	|    	|    	|
-  |Current Left   	|     	| S   	|  T 	| T  	|  O 	| O  	|  C 	| C  	| 
-  |...Right       	|     	| R   	|  W 	| W  	|  E 	| E  	|  Q 	| Q  	| 
-  |...Any         	|     	| SS  	|  TT	| TT 	|  OO	| OO 	|  CC	| CC 	| 
-  |+ Mandatory    	|!    	| !S  	|    	|    	|    	|    	|    	|    	|
-  |+ Optional     	|#    	| #S  	|    	|    	|    	|    	|    	|    	|
+  |↓Label type    	| Key→	|Shift	|Ctrl	|Ctrl	|Alt 	|Alt 	|Cmd 	|Cmd 	|Cmd 	|
+  |:--------------	| :-  	|  :-:	| :-:	| :-:	| :-:	| :-:	| :-:	| :-:	| :-:	|
+  |Any (mandatory)	|     	| ⇧   	|  ⎈ 	| ⌃  	|  ⎇ 	| ⌥  	| ⌘  	| ◆  	| ❖  	|
+  |+ Left         	|‹ `'`	| ‹⇧  	|    	|    	|    	|    	|    	|    	|    	|
+  |+ Right        	|› `'`	| ⇧›  	|    	|    	|    	|    	|    	|    	|    	|
+  |+ Optional     	|﹖ ?  	|   ⇧﹖	|    	|    	|    	|    	|    	|    	|    	|
+  |Current Left   	|     	| S   	|  T 	| T  	|  O 	| O  	|  C 	| C  	| C  	|
+  |...Right       	|     	| R   	|  W 	| W  	|  E 	| E  	|  Q 	| Q  	| Q  	|
+  |...Any         	|     	| SS  	|  TT	| TT 	|  OO	| OO 	|  CC	| CC 	| CC 	|
+  |+ Mandatory    	|!    	| !S  	|    	|    	|    	|    	|    	|    	|    	|
+  |+ Optional     	|#    	| #S  	|    	|    	|    	|    	|    	|    	|    	|
 
 Examples
 

--- a/KeySymbols.md
+++ b/KeySymbols.md
@@ -66,6 +66,7 @@ __NB!__
   |‐ ₌           	|`hyphen` `equal_sign`                     	|
   |▲ ▼ ◀ ▶       	|`up`/`down`/`left`/`right` `_arrow`
   |⇞ ⇟           	|`page_` `up`/`down`                    	|
+  |⎀             	|`insert`                               	|
   |⇤ ⤒ ↖         	|`home`                                 	|
   |⇥ ⤓ ↘         	|`end`                                  	|
   | ` `          	|no-break space removed                 	|

--- a/KeySymbols.md
+++ b/KeySymbols.md
@@ -13,16 +13,18 @@
 
 Examples
 
-  |New label      	| Side 	| Must/opt 	| Key    	|Old	|
-  |:--------------	| :-   	|  :-      	| :-     	| :-	|
-  |‹⇧             	| left 	| mandatory	| shift  	| !S	|
-  |⎈›             	| right	| mandatory	| control	| !W	|
-  |⎇›﹖            	| right	| optional 	| alt    	| #E	|
+  |New label      	| Side 	| Must/opt 	| Key    	|Old     	|
+  |:--------------	| :-   	|  :-      	| :-     	| :-     	|
+  |‹⇧             	| left 	| mandatory	| shift  	| !S     	|
+  |⎈›             	| right	| mandatory	| control	| !W     	|
+  |⎇›﹖            	| right	| optional 	| alt    	| #E     	|
+  |⎇›⇧            	| right	| optional 	| alt    	| !Eshift	|
 
 __NB!__
 
   - Left/Right side indicators __must__ be at their respective sides (‹Left, Right›)
   - Optional﹖ indicator __must__ bet at the Right side and __after__ the side indicator (✓`⎈›﹖` ✗`⎈﹖›`)
+  - Modifiers at the end of a key definition are treated as literal keys
 
 ### Other key symbols
 

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ questions there.
 
 ## Note
 
+- From/to key definitions can contain key symbols like ‹⇧ instead of !S for a left shift, more details at [List of supported key symbols](./KeySymbols.md)
 -  ~~Using `#_` to comment out rules [like
    this](https://github.com/yqrashawn/yqdotfiles/blob/2699f833f9431ca197d50f6905c825712f7aee8d/.config/karabiner.edn#L41)
    will leave a null rule (see below) in karabiner.json, it won't cause any

--- a/project.clj
+++ b/project.clj
@@ -11,6 +11,7 @@
                  [babashka/process "0.1.7"]
                  [cheshire "5.10.2"]
                  [com.github.clj-easy/graal-build-time "0.1.4"]]
-  :plugins [[lein-cloverage "1.2.3"]])
+  :plugins [[lein-cloverage "1.2.3"]]
+  :profiles {:socket {:jvm-opts ["-Dclojure.server.repl={:port 5555 :accept clojure.core.server/repl :server-daemon false}"]}})
 
 

--- a/project.clj
+++ b/project.clj
@@ -8,6 +8,7 @@
   :dependencies [[org.clojure/clojure "1.11.1"]
                  [org.clojure/tools.cli "1.0.206"]
                  [me.raynes/fs "1.4.6"]
+                 [org.clojure/core.match "1.0.1"]
                  [babashka/process "0.1.7"]
                  [cheshire "5.10.2"]
                  [com.github.clj-easy/graal-build-time "0.1.4"]]

--- a/src/karabiner_configurator/core.clj
+++ b/src/karabiner_configurator/core.clj
@@ -135,7 +135,8 @@
     (when (> (count edn-syntax-err) 0)
       (println "Syntax error in config:")
       (println edn-syntax-err)
-      (exit 1)))
+      ; (exit 1)
+      ))
   (update-to-karabiner-json (parse-edn (load-edn path)) dry-run dry-run-all))
 
 (defn open-log-file []

--- a/src/karabiner_configurator/core.clj
+++ b/src/karabiner_configurator/core.clj
@@ -25,7 +25,7 @@
 (defn check-edn-syntax
   "Call joker to check syntax of karabiner.edn"
   [path]
-  (-> @(p/process [(System/getenv "SHELL") "-i" "-c" (format "joker --lint %s" path)])
+  (-> (p/process {:out :string :err :string}[(System/getenv "SHELL") "-i" "-c" (format "joker --lint %s" path)])
       :err))
 
 (defn exit

--- a/src/karabiner_configurator/core.clj
+++ b/src/karabiner_configurator/core.clj
@@ -130,7 +130,8 @@
 (defn parse
   "Root function to parse karabiner.edn and update karabiner.json."
   [path & [dry-run dry-run-all]]
-  (let [edn-syntax-err (:err (check-edn-syntax path))]
+  (let [edn-syntax-err-stream (check-edn-syntax path)]
+    (def edn-syntax-err (slurp edn-syntax-err-stream))
     (when (> (count edn-syntax-err) 0)
       (println "Syntax error in config:")
       (println edn-syntax-err)

--- a/src/karabiner_configurator/keys_symbols.clj
+++ b/src/karabiner_configurator/keys_symbols.clj
@@ -202,18 +202,23 @@
   [k prefix]
   (def s (if (keyword? k)
     (name k)
+         (if (string? k)
           k
-  ))
-  (def modi-must [])
-  (let [[s-remain modi-must] (find-modi s prefix modi-must)]
-    (def modi-must-str
-      (if (empty? modi-must)
-        ""
-        (str prefix (string/replace (string/join "" modi-must) prefix "")) ; :!CC!AA → :!CCAA
+          nil
+  )))
+  (if (string? s) ; skip non-string keys like ["var" 1]
+    (do
+      (def modi-must [])
+      (let [[s-remain modi-must] (find-modi s prefix modi-must)]
+        (def modi-must-str
+          (if (empty? modi-must)
+            ""
+            (str prefix (string/replace (string/join "" modi-must) prefix "")) ; :!CC!AA → :!CCAA
+        ))
+        (keyword (str modi-must-str s-remain))
     ))
-    (keyword (str modi-must-str s-remain))
-    )
-  )
+    k
+  ))
 (defn move-modi-mandatory-front
   [k]
   (def prefix "!")

--- a/src/karabiner_configurator/keys_symbols.clj
+++ b/src/karabiner_configurator/keys_symbols.clj
@@ -8,13 +8,17 @@
 ; R W E Q → right_shift right_control right_option right_command
 ; SS      → shift ...
 ; labels must = same position
-(def modi-sym	["⇧" 	 "⎈" 	"⌃" 	 "⎇" 	"⌥" 	 "⌘" 	"◆" 	"❖" ])
-(def modi-‹l 	["S" 	 "T" 	"T" 	 "O" 	"O" 	 "C" 	"C" 	"C" ])
-(def modi-l› 	["R" 	 "W" 	"W" 	 "E" 	"E" 	 "Q" 	"Q" 	"Q" ])
-(def modi-l∀ 	["SS"	 "TT"	"TT"	 "OO"	"OO"	 "CC"	"CC"	"CC" ])
-(def ‹key    	["‹" "'"])
-(def key›    	["›" "'"])
-(def key﹖    	["﹖" "?"])
+(def modi-sym      	["⇧"    	 "⎈"      	"⌃"      	 "⎇"     	"⌥"     	 "⌘"      	"◆"      	"❖" ])
+(def modi-‹l       	["S"    	 "T"      	"T"      	 "O"     	"O"     	 "C"      	"C"      	"C" ])
+(def modi-l›       	["R"    	 "W"      	"W"      	 "E"     	"E"     	 "Q"      	"Q"      	"Q" ])
+(def modi-l∀       	["SS"   	 "TT"     	"TT"     	 "OO"    	"OO"    	 "CC"     	"CC"     	"CC" ])
+(def modi-l∀-as-key	["shift"	 "control"	"control"	 "option"	"option"	 "command"	"command"	"command" ])
+(def ‹key          	["‹" "'"])
+(def key›          	["›" "'"])
+(def key﹖          	["﹖" "?"])
+(def modi-‹l-as-key (mapv #(str "left_"  %) modi-l∀-as-key))
+(def modi-l›-as-key (mapv #(str "right_" %) modi-l∀-as-key))
+
 (def keys-symbols-other {
   "🌐" 	"!F","ƒ""!F","ⓕ""!F","Ⓕ""!F","🄵""!F","🅕""!F","🅵""!F"
   "⇪" 	"P"          	; capslock
@@ -64,6 +68,25 @@
          )) (concat ‹key '(nil))
   ))                modi-sym))
 )
+(def keys-symbols-generated-modi-as-key (into {} (
+  mapcat      (fn [mod]
+    (mapcat   (fn [‹]
+      (map    (fn [›]
+        (def mI	(.indexOf modi-sym mod)) ; modifier index to pick labels (which have the same position)
+        (def ‹l	(nth modi-‹l-as-key mI))
+        (def l›	(nth modi-l›-as-key mI))
+        (def l∀	(nth modi-l∀-as-key mI))
+        (match [ ; !mandatory ; #optional
+          (some? ‹) (some? ›)]
+          [true      false ]	{(str ‹ mod    )	‹l}
+          [false     true  ]	{(str   mod ›  )	l›}
+          [false     false ]	{(str   mod    )	l∀}
+          :else             	nil
+         )) (concat key› '(nil))
+         )) (concat ‹key '(nil))
+  ))                modi-sym))
+)
+
 (def keys-symbols-unordered (merge keys-symbols-generated keys-symbols-other))
 ; Sort by key length (BB > A) to match ⇧› before ⇧
 (defn sort-map-key-len
@@ -74,7 +97,8 @@
       (if (or (= ord "asc") (= ord "↑")) [(count (str key1)) key1] [(count (str key2)) key2])
       (if (or (= ord "asc") (= ord "↑")) [(count (str key2)) key2] [(count (str key1)) key1])
   ))) m)))
-(def keys-symbols (sort-map-key-len keys-symbols-unordered "↓"))
+(def keys-symbols             (sort-map-key-len keys-symbols-unordered             "↓"))
+(def keys-symbols-modi-as-key (sort-map-key-len keys-symbols-generated-modi-as-key "↓"))
 
 (defn replace-map-h "input string + hash-map ⇒ string with all map-keys → map-values in input"
   [s_in m_in]

--- a/src/karabiner_configurator/keys_symbols.clj
+++ b/src/karabiner_configurator/keys_symbols.clj
@@ -58,8 +58,17 @@
          )) (concat ‹key '(nil))
   ))                modi-sym))
 )
-(def keys-symbols (merge keys-symbols-generated keys-symbols-other))
-
+(def keys-symbols-unordered (merge keys-symbols-generated keys-symbols-other))
+; Sort by key length (BB > A) to match ⇧› before ⇧
+(defn sort-map-key-len
+  ([m    ] (sort-map-key-len m "asc"))
+  ([m ord] (into
+  (sorted-map-by (fn [key1 key2] (
+    compare
+      (if (or (= ord "asc") (= ord "↑")) [(count (str key1)) key1] [(count (str key2)) key2])
+      (if (or (= ord "asc") (= ord "↑")) [(count (str key2)) key2] [(count (str key1)) key1])
+  ))) m)))
+(def keys-symbols (sort-map-key-len keys-symbols-unordered "↓"))
 
 (defn replace-map-h "input string + hash-map ⇒ string with all map-keys → map-values in input"
   [s_in m_in]

--- a/src/karabiner_configurator/keys_symbols.clj
+++ b/src/karabiner_configurator/keys_symbols.clj
@@ -34,6 +34,7 @@
   "▼" 	"down_arrow"
   "◀" 	"left_arrow"
   "▶" 	"right_arrow"
+  " " 	"" ; no-break space removed, used only for rudimentary alignment
 })
 (def keys-symbols-generated (into {} (
   mapcat      (fn [mod]

--- a/src/karabiner_configurator/keys_symbols.clj
+++ b/src/karabiner_configurator/keys_symbols.clj
@@ -42,6 +42,7 @@
   "£"	"non_us_pound"
   "⇞"	"page_up","⇟""page_down"
   "⇤"	"home","⇥""end","⤒""home","⤓""end","↖""home","↘""end",
+  "⎀"	"insert",
   "ˋ"	"grave_accent_and_tilde","˜""grave_accent_and_tilde"
   "␠"	"spacebar","␣""spacebar"
   "␈"	"delete_or_backspace","⌫""delete_or_backspace"

--- a/src/karabiner_configurator/keys_symbols.clj
+++ b/src/karabiner_configurator/keys_symbols.clj
@@ -59,3 +59,19 @@
   ))                modi-sym))
 )
 (def keys-symbols (merge keys-symbols-generated keys-symbols-other))
+
+
+(defn replace-map-h "input string + hash-map ⇒ string with all map-keys → map-values in input"
+  [s_in m_in]
+  (def keys_in     	(keys m_in))                                          	;{"⎇""A","⎈""C"} → "⎇""⎈"
+  (def keys_in_q   	(map #(java.util.regex.Pattern/quote %) keys_in))     	;"\\Q⎇\\E"   "\\Q⎈\\E"
+  (def keys_in_q_or	(interpose "|"                          keys_in_q))   	;"\\Q⎇\\E""|""\\Q⎈\\E"
+  (def keys_in_q_s 	(apply str                              keys_in_q_or))	;"\\Q⎇\\E|\\Q⎈\\E"
+  (def keys_in_re  	(re-pattern                             keys_in_q_s)) 	;#"\Q⎇\E|\Q⎈\E"
+  (string/replace s_in keys_in_re m_in))
+
+(defn key-name-sub-or-self [k]
+  (if (keyword? k)
+    (keyword (string/replace (replace-map-h k keys-symbols) #"^:" ""))
+    k
+  ))

--- a/src/karabiner_configurator/keys_symbols.clj
+++ b/src/karabiner_configurator/keys_symbols.clj
@@ -136,13 +136,13 @@
 
 (defn replace-map-h "input string + hash-map ⇒ string with all map-keys → map-values in input"
   [s_in m_in & {:keys [modi-as-key] :or {modi-as-key nil}}]
-  (def keys_in     	(keys m_in))                     	              	;{"⎇""A","⎈""C"} → "⎇""⎈"
-  (if modi-as-key  	                                 	              	;
-    (def keys_in_q 	(map #(str (Pattern/quote %) "$")	keys_in))     	;"\\Q⎇\\E"   "\\Q⎈\\E" + "$" if passed
-    (def keys_in_q 	(map #(     Pattern/quote %)     	keys_in))     	)
-  (def keys_in_q_or	(interpose "|"                   	keys_in_q))   	;"\\Q⎇\\E""|""\\Q⎈\\E"
-  (def keys_in_q_s 	(apply str                       	keys_in_q_or))	;"\\Q⎇\\E|\\Q⎈\\E"
-  (def keys_in_re  	(re-pattern                      	keys_in_q_s)) 	;#"\Q⎇\E|\Q⎈\E"
+  (def keys_in     	(keys m_in))                               	              	;{"⎇""A","⎈""C"} → "⎇""⎈"
+  (if modi-as-key  	                                           	              	;
+    (def keys_in_q 	(map #(str #"(?<!_)" (Pattern/quote %) "$")	keys_in))     	;"\\Q⎇\\E"   "\\Q⎈\\E" + "$" if passed
+    (def keys_in_q 	(map #(str #"(?<!_)" (Pattern/quote %)    )	keys_in))     	)
+  (def keys_in_q_or	(interpose "|"                             	keys_in_q))   	;"\\Q⎇\\E""|""\\Q⎈\\E"
+  (def keys_in_q_s 	(apply str                                 	keys_in_q_or))	;"\\Q⎇\\E|\\Q⎈\\E"
+  (def keys_in_re  	(re-pattern                                	keys_in_q_s)) 	;#"\Q⎇\E|\Q⎈\E"
   (string/replace s_in keys_in_re m_in)
   )
 

--- a/src/karabiner_configurator/keys_symbols.clj
+++ b/src/karabiner_configurator/keys_symbols.clj
@@ -23,18 +23,23 @@
   "﹖﹖"	"##","??""##"	; optional any
   "︔" 	"semicolon"
   "⸴" 	"comma"
+  "．" 	"period"
   "⎋" 	"escape"
-  "⭾" 	"tab"
-  "␠" 	"spacebar"
-  "␣" 	"spacebar"
-  "␈" 	"delete_or_backspace"
-  "⌫" 	"delete_or_backspace"
-  "⏎" 	"return_or_enter"
-  "▲" 	"up_arrow"
-  "▼" 	"down_arrow"
-  "◀" 	"left_arrow"
-  "▶" 	"right_arrow"
+  "⭾" 	"tab","↹""tab"
+  "₌" 	"equal_sign"
+  "⇞" 	"page_up","⇟""page_down"
+  "⇤" 	"home","⇥""end","⤒""home","⤓""end","↖""home","↘""end",
+  "ˋ" 	"grave_accent_and_tilde","˜""grave_accent_and_tilde"
+  "␠" 	"spacebar","␣""spacebar"
+  "␈" 	"delete_or_backspace","⌫""delete_or_backspace"
+  "␡" 	"delete_forward","⌦""delete_forward"
+  "⏎" 	"return_or_enter","↩""return_or_enter","⌤""return_or_enter","␤""return_or_enter",
+  "▲" 	"up_arrow","▼""down_arrow","◀""left_arrow","▶""right_arrow"
   " " 	"" ; no-break space removed, used only for rudimentary alignment
+  "🔢₁""keypad_1","🔢₂""keypad_2","🔢₃""keypad_3","🔢₄""keypad_4","🔢₅""keypad_5"
+  "🔢₆""keypad_6","🔢₇""keypad_7","🔢₈""keypad_8","🔢₉""keypad_9","🔢₀""keypad_0"
+  "🔢₌""keypad_equal_sign","🔢₋""keypad_hyphen","🔢₊""keypad_plus"
+  "🔢⁄""keypad_slash","🔢．""keypad_period","🔢∗""keypad_asterisk"
 })
 (def keys-symbols-generated (into {} (
   mapcat      (fn [mod]

--- a/src/karabiner_configurator/keys_symbols.clj
+++ b/src/karabiner_configurator/keys_symbols.clj
@@ -22,9 +22,11 @@
 
 (def keys-symbols-other {
   "🌐" 	"!F","ƒ""!F","ⓕ""!F","Ⓕ""!F","🄵""!F","🅕""!F","🅵""!F"
-  "⇪" 	"P" 	; capslock
-  "∀" 	"!A"	; any regardless of side
-  "✱" 	"!!"	; hyper
+  "⇪" 	"P"    	; capslock
+  "∀" 	"!A"   	; any regardless of side
+  "✱›"	"!RWEQ"	; right-side "hyper"
+  "✦" 	"!RWEQ"	; right-side "hyper"
+  "✱" 	"!!"   	;  left-side "hyper"
   "∀﹖"	"##","∀?""##","﹖﹖""##","??""##"; optional any
   "︔" 	"semicolon"
   "“" 	"quote","”""quote","＂""quote","«""quote","»""quote"

--- a/src/karabiner_configurator/keys_symbols.clj
+++ b/src/karabiner_configurator/keys_symbols.clj
@@ -22,29 +22,58 @@
 
 (def keys-symbols-other {
   "🌐" 	"!F","ƒ""!F","ⓕ""!F","Ⓕ""!F","🄵""!F","🅕""!F","🅵""!F"
-  "⇪" 	"P"          	; capslock
-  "∀" 	"!A"         	; any regardless of side
-  "✱" 	"!!"         	; hyper
-  "﹖﹖"	"##","??""##"	; optional any
+  "⇪" 	"P" 	; capslock
+  "∀" 	"!A"	; any regardless of side
+  "✱" 	"!!"	; hyper
+  "∀﹖"	"##","∀?""##","﹖﹖""##","??""##"; optional any
   "︔" 	"semicolon"
-  "⸴" 	"comma"
-  "．" 	"period"
-  "⎋" 	"escape"
-  "⭾" 	"tab","↹""tab"
-  "₌" 	"equal_sign"
-  "⇞" 	"page_up","⇟""page_down"
-  "⇤" 	"home","⇥""end","⤒""home","⤓""end","↖""home","↘""end",
-  "ˋ" 	"grave_accent_and_tilde","˜""grave_accent_and_tilde"
-  "␠" 	"spacebar","␣""spacebar"
-  "␈" 	"delete_or_backspace","⌫""delete_or_backspace"
-  "␡" 	"delete_forward","⌦""delete_forward"
-  "⏎" 	"return_or_enter","↩""return_or_enter","⌤""return_or_enter","␤""return_or_enter",
-  "▲" 	"up_arrow","▼""down_arrow","◀""left_arrow","▶""right_arrow"
-  " " 	"" ; no-break space removed, used only for rudimentary alignment
+  "“" 	"quote","”""quote","＂""quote","«""quote","»""quote"
+  "⧵" 	"backslash","＼""backslash"
+  "﹨" "non_us_backslash"
+  "【"	"open_bracket" ,"「""open_bracket" ,"〔""open_bracket" ,"⎡""open_bracket"
+  "】"	"close_bracket","」""close_bracket","〕""close_bracket","⎣""close_bracket"
+  "⸴"	"comma"
+  "．"	"period"
+  "⁄"	"slash"
+  "⎋"	"escape"
+  "⭾"	"tab","↹""tab"
+  "‐"	"hyphen"
+  "₌"	"equal_sign"
+  "£"	"non_us_pound"
+  "⇞"	"page_up","⇟""page_down"
+  "⇤"	"home","⇥""end","⤒""home","⤓""end","↖""home","↘""end",
+  "ˋ"	"grave_accent_and_tilde","˜""grave_accent_and_tilde"
+  "␠"	"spacebar","␣""spacebar"
+  "␈"	"delete_or_backspace","⌫""delete_or_backspace"
+  "␡"	"delete_forward","⌦""delete_forward"
+  "⏎"	"return_or_enter","↩""return_or_enter","⌤""return_or_enter","␤""return_or_enter",
+  "▲"	"up_arrow","▼""down_arrow","◀""left_arrow","▶""right_arrow"
+  " "	"" ; no-break space removed, used only for rudimentary alignment
   "🔢₁""keypad_1","🔢₂""keypad_2","🔢₃""keypad_3","🔢₄""keypad_4","🔢₅""keypad_5"
   "🔢₆""keypad_6","🔢₇""keypad_7","🔢₈""keypad_8","🔢₉""keypad_9","🔢₀""keypad_0"
   "🔢₌""keypad_equal_sign","🔢₋""keypad_hyphen","🔢₊""keypad_plus"
-  "🔢⁄""keypad_slash","🔢．""keypad_period","🔢∗""keypad_asterisk"
+  "🔢⁄""keypad_slash","🔢．""keypad_period","🔢∗""keypad_asterisk","🔢⏎""keypad_enter"
+  "🔊""volume_up"  ,"🔈+""volume_up"  ,"🔈➕""volume_up"  ,"🔈₊""volume_up"  ,"🔈⊕""volume_up"
+  "🔉""volume_down","🔈−""volume_down","🔈➖""volume_down","🔈₋""volume_down","🔈⊖""volume_down"
+  "🔇""mute","🔈⓪""mute","🔈⓿""mute","🔈₀""mute"
+  "🔆""vk_consumer_brightness_up"
+  "🔅""vk_consumer_brightness_down"
+  "⌨💡+""vk_consumer_illumination_up"  ,"⌨💡➕""vk_consumer_illumination_up"  ,"⌨💡₊""vk_consumer_illumination_up"  ,"⌨💡⊕""vk_consumer_illumination_up"
+  "⌨💡−""vk_consumer_illumination_down","⌨💡➖""vk_consumer_illumination_down","⌨💡₋""vk_consumer_illumination_down","⌨💡⊖""vk_consumer_illumination_down"
+  "▦""vk_launchpad"
+  "🎛""vk_dashboard"
+  "▭▯""vk_mission_control"
+  "◀◀""vk_consumer_previous"
+  "▶⏸""vk_consumer_play"
+  "▶▶""vk_consumer_next"
+  "▤""application","☰""application","𝌆""application"
+  "🖰1" "button1" ,"🖰2" "button2" ,"🖰3" "button3" ,"🖰4" "button4" ,"🖰5" "button5"
+  "🖰6" "button6" ,"🖰7" "button7" ,"🖰8" "button8" ,"🖰9" "button9" ,"🖰10""button10"
+  "🖰11""button11","🖰12""button12","🖰13""button13","🖰14""button14","🖰15""button15"
+  "🖰16""button16","🖰17""button17","🖰18""button18","🖰19""button19"
+  "🖰21""button21","🖰22""button22","🖰23""button23","🖰24""button24","🖰25""button25"
+  "🖰26""button26","🖰27""button27","🖰28""button28","🖰29""button29","🖰30""button30"
+  "🖰31""button31","🖰32""button32"
 })
 (def keys-symbols-generated (into {} (
   mapcat      (fn [mod]

--- a/src/karabiner_configurator/keys_symbols.clj
+++ b/src/karabiner_configurator/keys_symbols.clj
@@ -1,0 +1,61 @@
+; Add various key symbols to be used instead of capitalized letters
+(ns karabiner-configurator.keys-symbols
+  (:require
+   [clojure.string :as string]
+   [clojure.core.match :refer [match]]))
+
+; S T O C → left_shift  left_control  left_option  left_command
+; R W E Q → right_shift right_control right_option right_command
+; SS      → shift ...
+; labels must = same position
+(def modi-sym	["⇧" 	 "⎈" 	"⌃" 	 "⎇" 	"⌥" 	 "⌘" 	"◆" ])
+(def modi-‹l 	["S" 	 "T" 	"T" 	 "O" 	"O" 	 "C" 	"C" ])
+(def modi-l› 	["R" 	 "W" 	"W" 	 "E" 	"E" 	 "Q" 	"Q" ])
+(def modi-l∀ 	["SS"	 "TT"	"TT"	 "OO"	"OO"	 "CC"	"CC" ])
+(def ‹key    	["‹" "'"])
+(def key›    	["›" "'"])
+(def key﹖    	["﹖" "?"])
+(def keys-symbols-other {
+  "🌐" 	"!F","ƒ""!F","ⓕ""!F","Ⓕ""!F","🄵""!F","🅕""!F","🅵""!F"
+  "⇪" 	"P"          	; capslock
+  "∀" 	"!A"         	; any regardless of side
+  "✱" 	"!!"         	; hyper
+  "﹖﹖"	"##","??""##"	; optional any
+  "︔" 	"semicolon"
+  "⸴" 	"comma"
+  "⎋" 	"escape"
+  "⭾" 	"tab"
+  "␠" 	"spacebar"
+  "␣" 	"spacebar"
+  "␈" 	"delete_or_backspace"
+  "⌫" 	"delete_or_backspace"
+  "⏎" 	"return_or_enter"
+  "▲" 	"up_arrow"
+  "▼" 	"down_arrow"
+  "◀" 	"left_arrow"
+  "▶" 	"right_arrow"
+})
+(def keys-symbols-generated (into {} (
+  mapcat      (fn [mod]
+    (mapcat   (fn [‹]
+      (mapcat (fn [›]
+        (map  (fn [﹖]
+        (def mI	(.indexOf modi-sym mod)) ; modifier index to pick labels (which have the same position)
+        (def ‹l	(nth modi-‹l mI))
+        (def l›	(nth modi-l› mI))
+        (def l∀	(nth modi-l∀ mI))
+        (match [ ; !mandatory ; #optional
+          (some? ‹) (some? ›) (some? ﹖)]
+          [true      false     false]	{(str ‹ mod    ) 	(str "!" ‹l)}
+          [false     true      false]	{(str   mod ›  ) 	(str "!" l›)}
+          [false     false     false]	{(str   mod    ) 	(str "!" l∀)}
+          [true      false     true] 	{(str ‹ mod   ﹖ )	(str "#" ‹l)}
+          [false     true      true] 	{(str   mod › ﹖ )	(str "#" l›)}
+          [false     false     true] 	{(str   mod   ﹖ )	(str "#" l∀)}
+          :else                      	nil
+         )) (concat key﹖ '(nil))
+         )) (concat key› '(nil))
+         )) (concat ‹key '(nil))
+  ))                modi-sym))
+)
+(def keys-symbols (merge keys-symbols-generated keys-symbols-other))

--- a/src/karabiner_configurator/keys_symbols.clj
+++ b/src/karabiner_configurator/keys_symbols.clj
@@ -141,6 +141,6 @@
     (def sub (move-modi-prefix-front sub1))
     (def sub                                sub1 )
     )
-  (if (and (some? dbg) (not= k sub)) (println (str "  " dbg "¦" k " ⟶⟶⟶ " sub)))
+  ; (if (and (some? dbg) (not= k sub)) (println (str "  " dbg "¦" k " ⟶⟶⟶ " sub)))
   sub
 )

--- a/src/karabiner_configurator/keys_symbols.clj
+++ b/src/karabiner_configurator/keys_symbols.clj
@@ -155,16 +155,22 @@
     (apply (partial update-in m ks f) args)
     m))
 
+(defn despace "replace all whitespace" [str_in]
+  (string/replace str_in #"[\s]" "")
+  )
 (defn key-name-sub-or-self [k]
-  (if (keyword? k)
+  (if     (keyword?  k)
     (do
       (def k1 (replace-map-h k  keys-symbols-modi-as-key :modi-as-key true)) ; first replace modi-as-keys
       (def k2 (replace-map-h k1 keys-symbols)) ; then replace other key symbols
       (keyword (string/replace k2 #"^:" ""))
       )
-    (if (map?   k)
+    (if   (map?      k)
       (update-in-if-has k [:key] key-name-sub-or-self)
-      k
+      (if (and (string?   k) (string/starts-with? k "‘"))
+        (key-name-sub-or-self (keyword (string/replace (despace k) #"^‘" "")))
+        k
+        )
       )
   )
 )

--- a/src/karabiner_configurator/keys_symbols.clj
+++ b/src/karabiner_configurator/keys_symbols.clj
@@ -8,10 +8,10 @@
 ; R W E Q → right_shift right_control right_option right_command
 ; SS      → shift ...
 ; labels must = same position
-(def modi-sym	["⇧" 	 "⎈" 	"⌃" 	 "⎇" 	"⌥" 	 "⌘" 	"◆" ])
-(def modi-‹l 	["S" 	 "T" 	"T" 	 "O" 	"O" 	 "C" 	"C" ])
-(def modi-l› 	["R" 	 "W" 	"W" 	 "E" 	"E" 	 "Q" 	"Q" ])
-(def modi-l∀ 	["SS"	 "TT"	"TT"	 "OO"	"OO"	 "CC"	"CC" ])
+(def modi-sym	["⇧" 	 "⎈" 	"⌃" 	 "⎇" 	"⌥" 	 "⌘" 	"◆" 	"❖" ])
+(def modi-‹l 	["S" 	 "T" 	"T" 	 "O" 	"O" 	 "C" 	"C" 	"C" ])
+(def modi-l› 	["R" 	 "W" 	"W" 	 "E" 	"E" 	 "Q" 	"Q" 	"Q" ])
+(def modi-l∀ 	["SS"	 "TT"	"TT"	 "OO"	"OO"	 "CC"	"CC"	"CC" ])
 (def ‹key    	["‹" "'"])
 (def key›    	["›" "'"])
 (def key﹖    	["﹖" "?"])

--- a/src/karabiner_configurator/keys_symbols.clj
+++ b/src/karabiner_configurator/keys_symbols.clj
@@ -133,3 +133,14 @@
   [k]
   (move-modi-front (move-modi-front k "#") "!")
   )
+(defn key-sym-to-key
+  "Takes key with symbols as input and returns keys without; optional :dbg debug print value"
+  [k & {:keys [dbg] :or {dbg nil}}]
+  (def sub1 (key-name-sub-or-self k))
+  (if (not= k sub1)
+    (def sub (move-modi-prefix-front sub1))
+    (def sub                                sub1 )
+    )
+  (if (and (some? dbg) (not= k sub)) (println (str "  " dbg "¦" k " ⟶⟶⟶ " sub)))
+  sub
+)

--- a/src/karabiner_configurator/rules.clj
+++ b/src/karabiner_configurator/rules.clj
@@ -3,6 +3,7 @@
    [karabiner-configurator.conditions :as conditions]
    [karabiner-configurator.data :as d :refer [pkey? k? special-modi-k? conf-data pointing-k? consumer-k? noti? softf? templates? devices? assoc-conf-data update-conf-data profile? raw-rule?]]
    [karabiner-configurator.froms :as froms]
+   [karabiner-configurator.keys-symbols :as keysym]
    [karabiner-configurator.misc :refer [massert contains??]]
    [karabiner-configurator.tos :as tos]))
 
@@ -14,8 +15,9 @@
 ;; {...}   | fallback to `froms` definition
 (defn from-key
   "generate normal from key config"
-  [des from]
+  [des from_]
   (let [result nil
+        from (keysym/key-sym-to-key from_ :dbg "from")
         _validate-from (massert (or (and (vector? from) (>= (count from) 2) (not-any? #(not (or (pkey? %) (k? %))) from))
                                     (and (keyword? from) (or (k? from) (special-modi-k? from) (contains? (:froms @conf-data) from)))
                                     (map? from))
@@ -90,8 +92,10 @@
         :else
         (vec
          (flatten
-          (for [v to] ;; this for only return flatten vector
+          (for [v_ to] ;; this for only return flatten vector
             (do
+              (def v v_)
+              (if (keyword? v) (def v (keysym/key-sym-to-key v :dbg "to[]")) )
               (massert (or (contains? (:tos @conf-data) v)
                            (k? v)
                            (noti? v)
@@ -140,8 +144,9 @@
 ;; [{:set ["variable name" "variable value"]}] | set variable's value to string (fallback to `tos` definition)
 (defn to-key
   "generate to config"
-  [des to]
+  [des to_]
   (let [result nil
+        to (keysym/key-sym-to-key to_ :dbg "to  ")
         _validate-to (massert (or (and (keyword? to) (or (k? to)
                                                          (special-modi-k? to)
                                                          (contains? (:input-sources @conf-data) to)

--- a/test/karabiner_configurator/keys_symbols_test.clj
+++ b/test/karabiner_configurator/keys_symbols_test.clj
@@ -1,0 +1,62 @@
+(ns karabiner-configurator.keys-symbols-test
+  (:require [clojure.test                        :as t]
+            [karabiner-configurator.rules        :as rules]
+            [karabiner-configurator.keys-symbols :as sut]))
+
+;; convert symbols
+(def symbol-map {
+  :⇧k   	:!SSk,
+  :‹⇧k  	:!Sk,
+  :⇧›k  	:!Rk,
+  :⎇k   	:!OOk,
+  :‹⌘k  	:!Ck,
+  :⎇⇧b  	:!OO!SSb,
+  :‹⎈##3	:!T##3
+  :🌐    	:!F
+})
+
+;; convert modifiers
+(def modi-map {
+  :!OO!SSb     	:!OOSSb,
+  :!CC!TT      	:!CCTT,
+  :!CC!AA#BB!TT	:!CCAATT#BB,
+  :!!##i       	:!!##i,
+  :!CC!TT#CC#TT :!CCTT#CCTT
+})
+
+
+;; convert keys with modifiers
+(def key-modi-map {
+  :⇧›1              	:!R1
+  :⎈semicolon       	:!TTsemicolon
+  :⎈quote           	:!TTquote
+  :⎈spacebar        	:!TTspacebar
+  :◆›z              	:!Qz
+  :◆›period         	:!Qperiod
+  :Ⓕnon_us_backslash	:!Fnon_us_backslash
+  :‹◆d              	:!Cd
+  :⇧‹◆f10           	:!SSCf10
+})
+
+;; convert map of keys with modifiers
+(def map-key-modi-map {
+  {:key :⎈›a, :halt true}	{:key :!Wa, :halt true}
+})
+
+(t/deftest convert-symbols
+  (t/testing "convert symbols"
+    (doseq [[k v] symbol-map]
+      (t/is (= (sut/key-name-sub-or-self k) v))))
+
+  (t/testing "move mandatory/optional prefix from individual modifiers to a group"
+    (doseq [[k v] modi-map]
+      (t/is (= (sut/move-modi-prefix-front k) v))))
+
+  (t/testing "convert key with symbol modifiers to regular keys"
+    (doseq [[k v] key-modi-map]
+      (t/is (= (sut/key-sym-to-key k) v))))
+
+  (t/testing "convert map with :key with symbol modifiers to regular keys"
+    (doseq [[k v] map-key-modi-map]
+      (t/is (= (sut/key-sym-to-key k) v))))
+  )

--- a/test/karabiner_configurator/keys_symbols_test.clj
+++ b/test/karabiner_configurator/keys_symbols_test.clj
@@ -48,6 +48,17 @@
   :⇧＼               	:!SSbackslash
 })
 
+;; convert keys as strings
+(def key-string-map {
+  "‘  	 ⇧ 	  	 	k"	:!SSk,
+  "‘  	‹⇧ 	  	 	k"	:!Sk,
+  "‘  	 ⇧›	  	 	k"	:!Rk,
+  "‘  	   	  	⎇	k"	:!OOk,
+  "‘  	   	‹⌘	 	k"	:!Ck,
+  "‘  	 ⇧ 	  	⎇	k"	:!SSOOk,
+  "‘‹⎈	   	  	 	k"	:!Tk
+})
+
 ;; convert map of keys with modifiers
 (def map-key-modi-map {
   {:key :⎈›a, :halt true}	{:key :!Wa, :halt true}
@@ -68,5 +79,9 @@
 
   (t/testing "convert map with :key with symbol modifiers to regular keys"
     (doseq [[k v] map-key-modi-map]
+      (t/is (= (sut/key-sym-to-key k) v))))
+
+  (t/testing "convert map with 'keys as strings'"
+    (doseq [[k v] key-string-map]
       (t/is (= (sut/key-sym-to-key k) v))))
   )

--- a/test/karabiner_configurator/keys_symbols_test.clj
+++ b/test/karabiner_configurator/keys_symbols_test.clj
@@ -36,6 +36,8 @@
   :Ⓕnon_us_backslash	:!Fnon_us_backslash
   :‹◆d              	:!Cd
   :⇧‹◆f10           	:!SSCf10
+  :⎇›⇧              	:!Eshift
+  :⎇›⇪              	:!Ecaps_lock
 })
 
 ;; convert map of keys with modifiers

--- a/test/karabiner_configurator/keys_symbols_test.clj
+++ b/test/karabiner_configurator/keys_symbols_test.clj
@@ -49,6 +49,8 @@
   ; more complicated cases in vertically aligned pairs
   [:w {:set ["␠w" 1]  :repeat false} [:!␠w       ]] ; skip conversion of variable values
   [:w {:set ["␠w" 1], :repeat false} [:!spacebarw]]
+  [:⁄     [:say_␠h :repeat false]] ; skip conversion of user functions with _escaped symbols
+  [:slash [:say_␠h :repeat false]]
 })
 
 ;; convert keys as strings

--- a/test/karabiner_configurator/keys_symbols_test.clj
+++ b/test/karabiner_configurator/keys_symbols_test.clj
@@ -46,6 +46,9 @@
   :⇧﹨               	:!SSnon_us_backslash
   :⇧⧵               	:!SSbackslash
   :⇧＼               	:!SSbackslash
+  ; more complicated cases in vertically aligned pairs
+  [:w {:set ["␠w" 1]  :repeat false} [:!␠w       ]] ; skip conversion of variable values
+  [:w {:set ["␠w" 1], :repeat false} [:!spacebarw]]
 })
 
 ;; convert keys as strings

--- a/test/karabiner_configurator/keys_symbols_test.clj
+++ b/test/karabiner_configurator/keys_symbols_test.clj
@@ -61,7 +61,10 @@
 
 ;; convert map of keys with modifiers
 (def map-key-modi-map {
-  {:key :⎈›a, :halt true}	{:key :!Wa, :halt true}
+  {:key :⎈›a, :halt true}   	{:key :!Wa, :halt true}
+  {:sim[:₌ :␈]}             	{:sim [:equal_sign :delete_or_backspace]},
+  {:sim[:₌ :␈] :modi :any}  	{:sim [:equal_sign :delete_or_backspace] :modi :any}
+  {:sim["‘₌" :␈] :modi :any}	{:sim [:equal_sign :delete_or_backspace] :modi :any}
 })
 
 (t/deftest convert-symbols

--- a/test/karabiner_configurator/keys_symbols_test.clj
+++ b/test/karabiner_configurator/keys_symbols_test.clj
@@ -38,6 +38,14 @@
   :⇧‹◆f10           	:!SSCf10
   :⎇›⇧              	:!Eshift
   :⎇›⇪              	:!Ecaps_lock
+  :⇧⁄               	:!SSslash
+  :⇧〔               	:!SSopen_bracket
+  :⇧【               	:!SSopen_bracket
+  :⇧「               	:!SSopen_bracket
+  :⇧‐               	:!SShyphen
+  :⇧﹨               	:!SSnon_us_backslash
+  :⇧⧵               	:!SSbackslash
+  :⇧＼               	:!SSbackslash
 })
 
 ;; convert map of keys with modifiers


### PR DESCRIPTION
This PR adds a new great feature allowing using various ⇧symbols instead of R: see https://github.com/eugenesvk/GokuRakuJoudo/blob/symbol/KeySymbols.md for a brief overview or the linked issue

It works by prepending replacement functions that convert `⇧›`→`!R` before calling the existing from/to parsers

- Adds generated symbol data tables (allows to easier add variants like `?` and `﹖`, just add it in a list and the full table will be auto-regenerated)
- Adds various symbol helper functions
- Adds a few tests of the new  keys-symbols functions
- Adds ReadMe reference and a more detailed file with allowed key tables
- Allow using strings as keys (with a special `‘` symbol at the start to differentiate from regular strings like `osascript`, not sure if `'` would work)

A few TODOs:
 - exiting on syntax warnings is disabled, I don't know why joker is so strict and doesn't accept valid identifier symbols, and how to make it less strict (previously these were broken anyway, so I had variable names with special symbols, and there were no warnings shown, but I understand now why goku would sometimes hang forever if I added a few more vars like that)

Fixes a couple of bugs:
- Also found a weird bug that hanged the whole process on many warnings, and from https://github.com/babashka/process I understood that what you had with`@` proc deref was fine, but testing it turned out that no deref was the right way, not sure what's going on there
- Another one was syntax warnings were just swallowed, only errors bubbled up since the process exited

Closes https://github.com/yqrashawn/GokuRakuJoudo/issues/205