### PR TITLE
docs: fix broken karabiner links

### DIFF
--- a/examples.org
+++ b/examples.org
@@ -292,10 +292,10 @@ Don't map a to b when there are three fingers on the trackpad.
                       :sim     250
                       ;; to_delayed_action_delay_milliseconds
                       ;; checkout karabiner's documentation
-                      ;; https://pqrs.org/osx/karabiner/json.html
+                      ;; https://karabiner-elements.pqrs.org/docs/json/complex-modifications-manipulator-definition/to-delayed-action/
                       ;; basically it means time after which the key press is count delayed
                       :delay   500
-                      ;; https://pqrs.org/osx/karabiner/json.html#to-if-alone
+                      ;; https://karabiner-elements.pqrs.org/docs/json/complex-modifications-manipulator-definition/to-if-alone/
                       ;; to_if_alone_timeout_milliseconds
                       ;; affects to_if_alone behavior
                       ;; simlayer is implemented with to_if_alone and simultaneous key press feature

--- a/src/karabiner_configurator/modifiers.clj
+++ b/src/karabiner_configurator/modifiers.clj
@@ -3,7 +3,7 @@
             [karabiner-configurator.misc :refer [massert]]))
 
 ;; this file parses modifier definitions
-;; spec https://pqrs.org/osx/karabiner/json.html#from-event-definition-modifiers
+;; spec https://karabiner-elements.pqrs.org/docs/json/complex-modifications-manipulator-definition/from/modifiers/
 
 ;; user can define modifier combination in advance and use it in `froms`, `tos` or `rules`
 ;; it will generate a {:mandatory ["modifiers or empty"] :optional ["modifiers or any or empty"]} data structure

--- a/tutorial.md
+++ b/tutorial.md
@@ -19,7 +19,7 @@
 
 # Intro
 
-Goku supports (almost?) all the features that Karabiner Elements provides via its [JSON spec](https://pqrs.org/osx/karabiner/json.html).
+Goku supports (almost?) all the features that Karabiner Elements provides via its [JSON spec](https://karabiner-elements.pqrs.org/docs/json/root-data-structure/).
 
 If you have any question or advice on how to improve the tool, just open an issue or ask questions in the [Telegram group](https://t.me/joinchat/UDlL5H7VIwAVK0_7).
 
@@ -103,7 +103,7 @@ You can find all keycode definition in [this file](https://github.com/yqrashawn/
     ;; HHKB-BT keyboard.
 ```
 
-The only condition that Goku does not support is [keyboard type](https://pqrs.org/osx/karabiner/json.html#condition-definition-keyboard-type).
+The only condition that Goku does not support is [keyboard type](https://karabiner-elements.pqrs.org/docs/json/complex-modifications-manipulator-definition/conditions/keyboard-type/).
 
 <a id="basic4"></a>
 
@@ -254,7 +254,7 @@ The rules above are not really useful. Cause we lose `w` key in the first rule a
 
 ### froms and tos
 
-So in the karabiner.json spec, there're [from event definition](https://pqrs.org/osx/karabiner/json.html#from-event-definition) and [to event definition](https://pqrs.org/osx/karabiner/json.html#to-event-definition). We can predefine this in Goku as well.
+So in the karabiner.json spec, there're [from event definition](https://karabiner-elements.pqrs.org/docs/json/complex-modifications-manipulator-definition/from/) and [to event definition](https://karabiner-elements.pqrs.org/docs/json/complex-modifications-manipulator-definition/to/). We can predefine this in Goku as well.
 
 1.  froms definition
 
@@ -329,7 +329,7 @@ In karabiner, there's two kinds of layers implementation. I'll just call them th
 
 There're two problems in old layer. When we type "w1" really fast, we trigger the "1" in w layer rather than insert "w1". When we keep press w key down, the w key won't repeat. There won't be a "wwwwwwwwwwwwwwwwwwww".
 
-The karabiner's simlayer is based on its [simultaneous](https://pqrs.org/osx/karabiner/json.html#simultaneous) functionality. It's like this. The `-->` is the symbol of time.
+The karabiner's simlayer is based on its [simultaneous](https://karabiner-elements.pqrs.org/docs/json/complex-modifications-manipulator-definition/from/simultaneous/) functionality. It's like this. The `-->` is the symbol of time.
 
 ```
         press w key down --> if in threshold milliseconds
@@ -375,8 +375,8 @@ This solves those two problems. But we need to trigger the second key fast, or t
 
         ;; so we have a <other options> here, and we know that <conditions> can be nil
 
-        ;; rule is actually the manipulator in karabienr.json, checkout here
-        ;; https://pqrs.org/osx/karabiner/json.html#complex_modifications-manipulator-definition
+        ;; rule is actually the manipulator in karabiner.json, checkout here
+        ;; https://karabiner-elements.pqrs.org/docs/json/complex-modifications-manipulator-definition/
 
         ;; We can see there are ~type~, ~from~, ~to~, ~to_if_alone~, ~to_if_held_down~,
         ;; ~to_after_key_up~, ~to_delayed_action~, ~description~, ~conditions~,


### PR DESCRIPTION
The Karabiner Elements Documentation website structure has changed resulting in lots of 404s, so I updated the links to point to the current pages.

Determining the new pages was mostly straightforward with one minor exception which I [commented on below](https://github.com/yqrashawn/GokuRakuJoudo/pull/255#discussion_r1794214756).