### PR TITLE
Add support for sticky modifiers

### DIFF
--- a/examples.org
+++ b/examples.org
@@ -412,3 +412,43 @@ This setup can be used for keybindings where you press one key, then quickly ano
            ; when another key is invoked, or after a timeout, set the mode back to zero
            :delayed {:invoked ["right-shift-mode" 0] :canceled ["right-shift-mode" 0]}}]]}
 #+END_SRC
+
+** Sticky Modifiers
+
+Sticky modifiers allow you to press a modifier key once to make it "stick" until the next key press. This is useful for accessibility or when you want to avoid holding down modifier keys.
+
+#+NAME: sticky modifiers
+#+BEGIN_SRC clojure
+{:tos {:sticky-right-shift {:sticky {:right_shift :toggle}}
+       :sticky-left-cmd {:sticky {:left_command :on}}
+       :sticky-fn-off {:sticky {:fn :off}}}
+ :main
+ [{:des "sticky modifier examples"
+   :rules [
+           ; Press right_shift alone to toggle sticky right_shift
+           [:right_shift :right_shift nil {:alone :sticky-right-shift}]
+           ; Press caps_lock to turn on sticky left_command
+           [:caps_lock :sticky-left-cmd]
+           ; Press escape to turn off sticky fn
+           [:escape :sticky-fn-off]]}]}
+#+END_SRC
+
+Available sticky modifier keys:
+- left_control, left_shift, left_option, left_command
+- right_control, right_shift, right_option, right_command
+- fn
+
+Available sticky modifier values:
+- :on - always activates the sticky modifier
+- :off - always deactivates the sticky modifier
+- :toggle - toggles the sticky modifier (recommended for most cases)
+
+Note: You can only specify one modifier key per sticky modifier definition. If you want to activate multiple sticky modifiers, put multiple sticky_modifier definitions in a vector:
+
+#+BEGIN_SRC clojure
+{:tos {:multi-sticky [{:sticky {:left_control :toggle}}
+                      {:sticky {:left_shift :toggle}}]}
+ :main
+ [{:des "activate multiple sticky modifiers"
+   :rules [[:spacebar :multi-sticky]]}]}
+#+END_SRC

--- a/install-dev-software.sh
+++ b/install-dev-software.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Install leiningen for clojure
+if ! command -v lein &>/dev/null; then
+  echo "Installing leiningen..."
+  brew install leiningen
+else
+  echo "leiningen is already installed"
+fi
+
+# Install java and nativeimage for creating release binaries
+if ! command -v java &>/dev/null; then
+  echo "java 21.0.5-graal is not installed"
+
+  if [ ! -d "$HOME/.sdkman" ]; then
+    echo "Installing sdkman..."
+    curl -s "https://get.sdkman.io" | bash
+    source "$HOME/.sdkman/bin/sdkman-init.sh"
+  else
+    echo "sdkman is already installed"
+  fi
+
+  echo "Installing java 21.0.5-graal..."
+  sdk install java 21.0.5-graal
+else
+  echo "java 21.0.5-graal is already installed"
+fi
+
+if ! command -v native-image &>/dev/null; then
+  echo "Installing nativeimage..."
+  sdk install nativeimage
+else
+  echo "nativeimage is already installed"
+fi

--- a/test/karabiner_configurator/tos_test.clj
+++ b/test/karabiner_configurator/tos_test.clj
@@ -28,7 +28,12 @@
    :17 {:key :!CT#OFa}
    :18 {:shell [:launch "Mail"]}
    :19 {:select_input_source
-        {:input_source_id "^com\\.apple\\.keylayout\\.ABC$"}}})
+        {:input_source_id "^com\\.apple\\.keylayout\\.ABC$"}}
+   :20 {:sticky {:right_shift :toggle}}
+   :21 {:sticky {:left_command :on}}
+   :22 {:sticky {:fn :off}}
+   :23 [{:sticky {:left_control :toggle}}
+        {:sticky {:right_option :on}}]})
 
 (def result {:applications {}
              :tos {:18 [{:shell_command "osascript -e 'tell application \"Alfred 3\" to run trigger \"launchMail\" in workflow \"yqrashawn.workflow.launcher\" with argument \"\"'"}]
@@ -80,7 +85,12 @@
                         :key_code "d"}]
                    :6 [{:modifiers ["left_command" "right_shift"]
                         :key_code "d"}]
-                   :19 [{:select_input_source {:input_source_id "^com\\.apple\\.keylayout\\.ABC$"}}]}
+                   :19 [{:select_input_source {:input_source_id "^com\\.apple\\.keylayout\\.ABC$"}}]
+                   :20 [{:sticky_modifier {"right_shift" "toggle"}}]
+                   :21 [{:sticky_modifier {"left_command" "on"}}]
+                   :22 [{:sticky_modifier {"fn" "off"}}]
+                   :23 [{:sticky_modifier {"left_control" "toggle"}}
+                        {:sticky_modifier {"right_option" "on"}}]}
              :input-sources {:squirrel {:input_mode_id "com.googlecode.rimeime.inputmethod.Squirrel"
                                         :input_source_id "com.googlecode.rimeime.inputmethod.Squirrel.Rime"
                                         :language "zh-Hans"}

--- a/tutorial.md
+++ b/tutorial.md
@@ -304,7 +304,7 @@ The simultaneous<sub>options</sub> won't be used frequently. You can find the th
 
     Tos is used more often than froms. It's the same idea as froms definition. You can find the detailed [tos documentation](https://github.com/yqrashawn/GokuRakuJoudo/blob/master/src/karabiner_configurator/tos.clj#L7) in the implementation file. There are shortcuts for tos in rules, like string to shell commands and multiple to definitions in vector.
 
-    You only need to use to definition if you want to use or set `select_input_source`, `mouse_key`, `lazy`, `repeat`, `halt`, `hold_down_milliseconds`.
+    You only need to use to definition if you want to use or set `select_input_source`, `mouse_key`, `lazy`, `repeat`, `halt`, `hold_down_milliseconds`, `sticky_modifier`.
 
 <a id="advance3"></a>
 


### PR DESCRIPTION
Karabiner was messing with QMK one shot mods, so moved sticky logic to Karabiner.  Found out Goku didn't support sticky mods.

Added the following to my config:

```clojure
:tos {
    :sticky-left-shift {:sticky {:left_shift :toggle}}
}
```

```clojure
{:des "Sticky Left Shift"
         :rules [
                 [:##left_shift :left_shift :my_custom_condition {:alone :sticky-left-shift}]
]} 
```

karabiner.json output:

```json
{
  "to_if_alone" : [ {
    "sticky_modifier" : {
      "left_shift" : "toggle"
    }
  } ],
  "from" : {
    "key_code" : "left_shift",
    "modifiers" : {
      "optional" : [ "any" ]
    }
  },
  "to" : [ {
    "key_code" : "left_shift"
  } ],
  "conditions" : [ {
    "identifiers" : [ { ...:my_custom_condition... } ],
    "type" : "device_if"
  } ],
  "type" : "basic"
}
```

Works 👌